### PR TITLE
FIX(package.json) - Specify dir for eslint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "mocha": "^2.3.3"
     },
     "scripts": {
-        "lint": "eslint $(git ls-files '*.js')",
+        "lint": "eslint $(git ls-files './lib/*.js' './tests/*/*.js')",
         "test": "mocha -r babel/register tests/unit",
         "tests_functional": "make -C tests/functional"
     },


### PR DESCRIPTION
Before we were running the linter on all the js files of the
repository but now we have the docs dir for the github pages.
So now we specify the lib and tests dirs.