### PR TITLE
CLEAN(logger)- Change logger in test for mocha-logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,15 +23,15 @@
         "protocol"
     ],
     "dependencies": {
-        "protobufjs": "^4.0.0",
-        "winston": "^1.1.0"
+        "protobufjs": "^4.0.0"
     },
     "devDependencies": {
         "babel": "^5.8.23",
         "babel-eslint": "^4.1.3",
         "eslint": "^1.5.1",
         "eslint-config-airbnb": "^0.0.9",
-        "mocha": "^2.3.3"
+        "mocha": "^2.3.3",
+        "mocha-logger": "1.0.4"
     },
     "scripts": {
         "lint": "eslint $(git ls-files './lib/*.js' './tests/*/*.js')",

--- a/tests/functional/simulTest.js
+++ b/tests/functional/simulTest.js
@@ -1,9 +1,6 @@
 import assert from 'assert';
 import crypto from 'crypto';
 import net from 'net';
-import util from 'util';
-
-import winston from 'winston';
 
 import kinetic from '../../index';
 
@@ -20,9 +17,6 @@ let connectionID = 0;
 let clusterVersion = 0;
 const newVersion = Buffer.from('1');
 
-const logger = new (winston.Logger)({
-    transports: [new (winston.transports.Console)({ level: 'error' })]
-});
 
 const requestsArr = [
     ['put', 'PUT_RESPONSE'],
@@ -130,7 +124,6 @@ function checkTest(request, requestResponse, options, optRes, done) {
         } catch (e) {
             return done(e);
         }
-        logger.info(util.inspect(pdu, {showHidden: false, depth: null}));
 
         if (pdu.getMessageType() === null ||
             kinetic.getOpName(pdu.getMessageType()) !== requestResponse) {
@@ -138,9 +131,6 @@ function checkTest(request, requestResponse, options, optRes, done) {
             clusterVersion = pdu.getClusterVersion();
             requestsLauncher(request, client, options, done);
         } else {
-            logger.info(util.inspect(pdu.getProtobuf(),
-                {showHidden: false, depth: null}));
-
             assert.deepEqual(pdu.getStatusCode(),
                 kinetic.errors.SUCCESS);
             assert.deepEqual(

--- a/tests/unit/kinetic.js
+++ b/tests/unit/kinetic.js
@@ -2,15 +2,12 @@ const assert = require('assert');
 const crypto = require('crypto');
 const util = require('util');
 
-const winston = require('winston');
+const mlog = require('mocha-logger');
 
 const kinetic = require('../../index');
 
 const connectionID = 0;
 const clusterVersion = 0;
-const logger = new (winston.Logger)({
-    transports: [new (winston.transports.Console)({ level: 'error' })]
-});
 
 describe('kinetic.PDU decoding()', () => {
     function checkDecoding(data, checkFunction, done) {
@@ -537,8 +534,8 @@ describe('kinetic.PDU decoding()', () => {
 
         try {
             const pdu = new kinetic.PDU(rawData);
-            logger.info(util.inspect(pdu.getProtobuf(),
-                {showHidden: false, depth: null}));
+            mlog.error('did not detect invalid version',
+                       util.inspect(pdu, {showHidden: false, depth: null}));
 
             done(new Error('Bad error throwing in _parse/constructor()'));
         } catch (e) {
@@ -555,7 +552,9 @@ describe('kinetic.PDU decoding()', () => {
 
         try {
             const pdu = new kinetic.PDU(rawData);
-            pdu;
+            mlog.error('did not detect PDU with truncated header',
+                       util.inspect(pdu, {showHidden: false, depth: null}));
+
             done(new Error("No error thrown"));
         } catch (e) {
             if (e.badLength)
@@ -574,7 +573,9 @@ describe('kinetic.PDU decoding()', () => {
 
         try {
             const pdu = new kinetic.PDU(rawData);
-            pdu;
+            mlog.error('did not detect PDU with truncated message',
+                       util.inspect(pdu, {showHidden: false, depth: null}));
+
             done(new Error("No error thrown"));
         } catch (e) {
             if (e.badLength)
@@ -593,8 +594,8 @@ describe('kinetic.PDU decoding()', () => {
 
         try {
             const pdu = new kinetic.PDU(rawData);
-            logger.info(util.inspect(pdu.getProtobuf(),
-                {showHidden: false, depth: null}));
+            mlog.error('did not detect PDU with bad HMAC',
+                       util.inspect(pdu, {showHidden: false, depth: null}));
 
             done(new Error('Bad error throwing in _parse/constructor()'));
         } catch (e) {


### PR DESCRIPTION
Before we using winston as a log level in the tests but this was not
necessary. So we decided to use mocha-logger that is a simple logger
for testing with mocha.
It will show the PDU if the test fail.

- Add the dependency in the package.json
- Remove winston dependency